### PR TITLE
chore: point graphly dependency to lod4hss-apps compat branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pyyaml
 python-dotenv
 plotly
 streamlit_code_editor
-git+https://github.com/mauvois/graphly.git@compat
+git+https://github.com/lod4hss-apps/graphly.git@compat


### PR DESCRIPTION
logre dev used to call graphly on a fork. now it calls lod4hss's graphly