### PR TITLE
Promote `dev` into `main` before starting the next Logre sprint.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ RDF4J_REPOSITORY=logre
 # LOGRE_SPARQL_PASSWORD=
 
 # Optional: timeout in seconds for SPARQL HTTP requests
-# LOGRE_SPARQL_TIMEOUT=12
+# LOGRE_SPARQL_TIMEOUT=120
 
 # Optional: initial line chunk size for N-Quads uploads
 # Logre auto-reduces this value when endpoint returns HTTP 413

--- a/src/dialogs/find_entity.py
+++ b/src/dialogs/find_entity.py
@@ -1,5 +1,6 @@
 import streamlit as st
 from requests.exceptions import HTTPError, ConnectionError, Timeout
+from urllib.parse import quote_plus
 from lib import state
 from lib.errors import get_HTTP_ERROR_message
 from lib.utils import get_max_length_text
@@ -69,9 +70,10 @@ def dialog_find_entity() -> None:
         )
 
         # Set the state selected entity as being the one chosen
-        for i, entity in enumerate(entities):
+        for entity in entities:
             entity_text = get_max_length_text(entity.get_text(comment=True), 90)
-            if st.button(entity_text, type="tertiary", key=f"dlg-find-entity-{i}"):
+            key = f"dlg-find-entity-{quote_plus(entity.uri)}"
+            if st.button(entity_text, type="tertiary", key=key):
                 state.set_entity_uri(entity.uri)
                 st.switch_page("pages/entity-card.py")
 

--- a/src/dialogs/find_entity.py
+++ b/src/dialogs/find_entity.py
@@ -1,6 +1,5 @@
 import streamlit as st
 from requests.exceptions import HTTPError, ConnectionError, Timeout
-from urllib.parse import quote_plus
 from lib import state
 from lib.errors import get_HTTP_ERROR_message
 from lib.utils import get_max_length_text
@@ -70,10 +69,9 @@ def dialog_find_entity() -> None:
         )
 
         # Set the state selected entity as being the one chosen
-        for entity in entities:
+        for i, entity in enumerate(entities):
             entity_text = get_max_length_text(entity.get_text(comment=True), 90)
-            key = f"dlg-find-entity-{quote_plus(entity.uri)}"
-            if st.button(entity_text, type="tertiary", key=key):
+            if st.button(entity_text, type="tertiary", key=f"dlg-find-entity-{i}"):
                 state.set_entity_uri(entity.uri)
                 st.switch_page("pages/entity-card.py")
 

--- a/src/lib/state.py
+++ b/src/lib/state.py
@@ -271,11 +271,9 @@ def parse_query_params() -> None:
             if data_bundle:
                 set_data_bundle(data_bundle)
 
-    # Entity URI: from query param to state whenever the URL targets another
-    # entity card. Unlike endpoint/bundle, entity links are expected to
-    # navigate within an already-initialized session.
+    # Entity URI: from query param to state only when it is currently unset.
     uri = __get_query_param_value("uri")
-    if uri and uri != get_entity_uri():
+    if uri and get_entity_uri() is None:
         set_entity_uri(uri)
 
 

--- a/src/lib/state.py
+++ b/src/lib/state.py
@@ -934,7 +934,7 @@ def deselect_bundle_after_endpoint_failure() -> None:
     if "has_config" in state:
         save_config()
 
-    timeout_seconds = os.getenv("LOGRE_SPARQL_TIMEOUT", "12")
+    timeout_seconds = os.getenv("LOGRE_SPARQL_TIMEOUT", "120")
     set_toast(
         f"Endpoint '{endpoint_name}' is unreachable (timeout {timeout_seconds}s). Data Bundle deselected.",
         icon=":material/warning:",

--- a/src/lib/state.py
+++ b/src/lib/state.py
@@ -271,9 +271,11 @@ def parse_query_params() -> None:
             if data_bundle:
                 set_data_bundle(data_bundle)
 
-    # Entity URI: from query param to state only when it is currently unset.
+    # Entity URI: from query param to state whenever the URL targets another
+    # entity card. Unlike endpoint/bundle, entity links are expected to
+    # navigate within an already-initialized session.
     uri = __get_query_param_value("uri")
-    if uri and get_entity_uri() is None:
+    if uri and uri != get_entity_uri():
         set_entity_uri(uri)
 
 

--- a/src/pages/entity-triples.py
+++ b/src/pages/entity-triples.py
@@ -130,6 +130,7 @@ else:
         def display_triple(
             statement: Statement,
             object_kind: str = "entity_or_literal",
+            key_suffix: str = "",
         ) -> None:
             col_sub, col_pred, col_obj, col_info = st.columns(
                 [6, 6, 6, 1], gap="medium", vertical_alignment="bottom"
@@ -153,7 +154,15 @@ else:
                 col_obj.markdown(f"> {object_text}")
 
             with col_info.container(horizontal=True, horizontal_alignment="right"):
-                key = f"btn-{statement.subject.uri}-{statement.predicate.uri}-{statement.object.uri if hasattr(statement.object, 'uri') else statement.object.literal}-info"
+                object_key = (
+                    statement.object.uri
+                    if hasattr(statement.object, "uri")
+                    else statement.object.literal
+                )
+                key = (
+                    f"btn-{statement.subject.uri}-{statement.predicate.uri}-{object_key}"
+                    f"-{key_suffix}-info"
+                )
                 kwargs = {
                     "statement": statement,
                     "prefixes": data_bundle.prefixes,
@@ -216,7 +225,9 @@ else:
             )
             entity_class = data_bundle.model.find_class(entity.class_uri)
             display_triple(
-                Statement(entity, prop_type, entity_class), object_kind="ontology"
+                Statement(entity, prop_type, entity_class),
+                object_kind="ontology",
+                key_suffix="basic-type",
             )
 
         # Label
@@ -227,7 +238,10 @@ else:
                 )
             )
             entity_label = Resource(entity.label, resource_type="literal")
-            display_triple(Statement(entity, prop_label, entity_label))
+            display_triple(
+                Statement(entity, prop_label, entity_label),
+                key_suffix="basic-label",
+            )
 
         # Comment
         if entity.comment:
@@ -239,7 +253,10 @@ else:
                 )
             )
             entity_comment = Resource(entity.comment, resource_type="literal")
-            display_triple(Statement(entity, comment, entity_comment))
+            display_triple(
+                Statement(entity, comment, entity_comment),
+                key_suffix="basic-comment",
+            )
 
         st.divider()
 
@@ -259,8 +276,8 @@ else:
         title_container.markdown(f"*{len(statements)} total outgoing triples*")
 
         # Display triples
-        for s in statements:
-            display_triple(s)
+        for i, s in enumerate(statements):
+            display_triple(s, key_suffix=f"out-{i}")
         if len(statements) == 0:
             st.markdown("*None*")
 
@@ -296,7 +313,7 @@ else:
             )
 
         # Display triples
-        for s in statements:
-            display_triple(s)
+        for i, s in enumerate(statements):
+            display_triple(s, key_suffix=f"in-{i}")
         if len(statements) == 0:
             st.markdown("*None*")

--- a/src/pages/import-export.py
+++ b/src/pages/import-export.py
@@ -64,7 +64,16 @@ with st.expander("Import"):
                 ):
 
                     def upload_nquads(nquad_content) -> None:
+                        print(
+                            f"[import] Upload n-quads start | endpoint={data_bundle.endpoint.name} | url={data_bundle.endpoint.url} | bundle={data_bundle.name}"
+                        )
                         data_bundle.endpoint.upload_nquads(nquad_content)
+                        print(
+                            f"[import] Upload n-quads complete | endpoint={data_bundle.endpoint.name} | bundle={data_bundle.name}"
+                        )
+                        print(
+                            f"[import] Reload model after n-quads upload | model_graph={data_bundle.model.uri}"
+                        )
                         data_bundle.load_model()
                         state.set_toast("n-Quad file uploaded", icon=":material/done:")
                         state.invalidate_caches("import_nquads")

--- a/src/schema/data_bundle.py
+++ b/src/schema/data_bundle.py
@@ -1,3 +1,4 @@
+import re
 from typing import List, Tuple, Dict
 import pandas as pd
 from requests.exceptions import HTTPError
@@ -121,6 +122,38 @@ class DataBundle:
                 message += f"\n\n{err.response.text}"
             raise Exception(message)
 
+    def _prepare_resource_uri(self, value: str | None) -> str | None:
+        """
+        Prepare a resource IRI for SPARQL patterns.
+
+        Unlike graphly.tools.prepare, this helper preserves absolute non-HTTP IRIs
+        (e.g. urn:, doi:) as IRIs instead of falling back to quoted literals.
+        """
+        if value is None:
+            return None
+
+        uri = str(value).strip()
+        if not uri:
+            return None
+
+        if uri.startswith("?"):
+            return uri
+
+        if uri.startswith("<") and uri.endswith(">"):
+            return uri
+
+        prefixes = self.prefixes.shorts()
+        prefix_sep = uri.find(":")
+        if prefix_sep > 0:
+            prefix = uri[:prefix_sep]
+            if prefix in prefixes:
+                return uri
+
+            if re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", uri):
+                return f"<{uri}>"
+
+        return prepare(uri, prefixes)
+
     def has_usable_model(self) -> bool:
         """
         Indicate whether the current bundle has any non-datatype classes or properties loaded.
@@ -182,9 +215,9 @@ class DataBundle:
             # DataBundle.find_entities()
             SELECT
                 (?uri_ as ?uri)
-                (COALESCE(?label_, '') as ?label)
-                (COALESCE(?comment_, '') as ?comment)
-                (COALESCE(?class_uri_, '{class_uri if class_uri else ""}') as ?class_uri)
+                (COALESCE(SAMPLE(?label_), '') as ?label)
+                (COALESCE(SAMPLE(?comment_), '') as ?comment)
+                (COALESCE(SAMPLE(?class_uri_), '{class_uri if class_uri else ""}') as ?class_uri)
             WHERE {{
                 {self.data.sparql_begin}
                     ?uri_ {self.model.type_property} {prepared_class_uri if prepared_class_uri else "?class_uri_"} .
@@ -193,6 +226,8 @@ class DataBundle:
                 {self.data.sparql_end}
                 {filter_clause}
             }}
+            GROUP BY ?uri_
+            ORDER BY LCASE(STR(?label)) STR(?uri)
             {f"LIMIT {limit}" if limit else ""}
             {f"OFFSET {offset}" if offset else ""}
         """
@@ -227,7 +262,7 @@ class DataBundle:
             List[Property]: A list of properties outgoing from the given entity.
         """
         # Prepare the query
-        entity_uri = prepare(entity.uri, self.prefixes.shorts())
+        entity_uri = self._prepare_resource_uri(entity.uri)
         query = f"""
             SELECT DISTINCT 
                 ?uri 
@@ -274,7 +309,7 @@ class DataBundle:
             List[Property]: A list of properties incoming to the given entity.
         """
         # Prepare the query
-        entity_uri = prepare(entity.uri, self.prefixes.shorts())
+        entity_uri = self._prepare_resource_uri(entity.uri)
         query = f"""
             SELECT DISTINCT 
                 ?uri 
@@ -347,7 +382,7 @@ class DataBundle:
             List[Statement]: A list of statements representing the entity-property-object triples.
         """
         # Prepare the query
-        entity_uri = prepare(entity.uri, self.prefixes.shorts())
+        entity_uri = self._prepare_resource_uri(entity.uri)
         property_uri = prepare(property.uri, self.prefixes.shorts())
         object_class_uri = prepare(
             property.range.uri if property.range else None, self.prefixes.shorts()
@@ -359,9 +394,9 @@ class DataBundle:
             # DataBundle.get_objects_of()
             SELECT
                 ?object_uri
-                (COALESCE(?object_label_, '') as ?object_label)
-                (COALESCE(?object_comment_, '') as ?object_comment)
-                (COALESCE(?object_class_uri_, IF(isLiteral(?object_uri), DATATYPE(?object_uri), '')) as ?object_class_uri)
+                (COALESCE(SAMPLE(?object_label_), '') as ?object_label)
+                (COALESCE(SAMPLE(?object_comment_), '') as ?object_comment)
+                (COALESCE(SAMPLE(?object_class_uri_), IF(isLiteral(?object_uri), DATATYPE(?object_uri), '')) as ?object_class_uri)
                 (IF(isIRI(?object_uri), 'iri', IF(isBlank(?object_uri), 'blank', IF(isLiteral(?object_uri), 'literal', ''))) as ?resource_type)
             WHERE {{
                 {self.data.sparql_begin}
@@ -372,15 +407,13 @@ class DataBundle:
                     OPTIONAL {{ ?object_uri {self.model.type_property} ?object_class_uri_ . }}
                 {self.data.sparql_end}
             }}
+            GROUP BY ?object_uri
             {f"LIMIT {limit}" if limit else ""}
             {f"OFFSET {offset}" if offset else ""}
         """
 
         # Execute query
         response = self.data.run(query)
-
-        # Make it unique based on object URI (can have duplicates because of multiple lables, comments, ...)
-        response = list({d["object_uri"]: d for d in reversed(response)}.values())
 
         # Parse response into Statement instance list
         statements = [
@@ -415,7 +448,7 @@ class DataBundle:
             int: The number of objects associated with the entity via the property.
         """
         # Prepare the query
-        entity_uri = prepare(entity.uri, self.prefixes.shorts())
+        entity_uri = self._prepare_resource_uri(entity.uri)
         property_uri = prepare(property.uri, self.prefixes.shorts())
         query = f"""
             # DataBundle.get_objects_of_count()
@@ -453,7 +486,7 @@ class DataBundle:
             List[Statement]: A list of statements representing the subject-property-entity triples.
         """
         # Prepare the query
-        entity_uri = prepare(entity.uri, self.prefixes.shorts())
+        entity_uri = self._prepare_resource_uri(entity.uri)
         property_uri = prepare(property.uri, self.prefixes.shorts())
         subject_class_uri = prepare(
             property.domain.uri if property.domain else None, self.prefixes.shorts()
@@ -462,9 +495,9 @@ class DataBundle:
             # DataBundle.get_subjects_of()
             SELECT
                 ?subject_uri
-                (COALESCE(?subject_label_, '') as ?subject_label)
-                (COALESCE(?subject_comment_, '') as ?subject_comment)
-                (COALESCE(?subject_class_uri_, IF(isLiteral(?subject_uri), DATATYPE(?subject_uri), '')) as ?subject_class_uri)
+                (COALESCE(SAMPLE(?subject_label_), '') as ?subject_label)
+                (COALESCE(SAMPLE(?subject_comment_), '') as ?subject_comment)
+                (COALESCE(SAMPLE(?subject_class_uri_), IF(isLiteral(?subject_uri), DATATYPE(?subject_uri), '')) as ?subject_class_uri)
                 (IF(isIRI(?subject_uri), 'iri', IF(isBlank(?subject_uri), 'blank', IF(isLiteral(?subject_uri), 'literal', ''))) as ?resource_type)
             WHERE {{
                 {self.data.sparql_begin}
@@ -475,15 +508,13 @@ class DataBundle:
                     OPTIONAL {{ ?subject_uri {self.model.type_property} ?subject_class_uri_ . }}
                 {self.data.sparql_end}
             }}
+            GROUP BY ?subject_uri
             {f"LIMIT {limit}" if limit else ""}
             {f"OFFSET {offset}" if offset else ""}
         """
 
         # Execute query
         response = self.data.run(query)
-
-        # Make it unique based on subject URI (can have duplicates because of multiple lables, comments, ...)
-        response = list({d["subject_uri"]: d for d in reversed(response)}.values())
 
         # Parse response into Statement instance list
         statements = [
@@ -518,7 +549,7 @@ class DataBundle:
             int: The number of subjects associated with the entity via the property.
         """
         # Prepare the query
-        entity_uri = prepare(entity.uri, self.prefixes.shorts())
+        entity_uri = self._prepare_resource_uri(entity.uri)
         property_uri = prepare(property.uri, self.prefixes.shorts())
         query = f"""
             # DataBundle.get_objects_of_count()
@@ -554,7 +585,7 @@ class DataBundle:
             List[Statement]: A list of statements representing the outgoing triples.
         """
         # Prepare the query
-        entity_uri = prepare(entity.uri, self.prefixes.shorts())
+        entity_uri = self._prepare_resource_uri(entity.uri)
         skip_prop_str = (
             ", ".join(
                 list(set([prepare(p.uri, self.prefixes.shorts()) for p in skip_props]))
@@ -564,10 +595,10 @@ class DataBundle:
         )
         query = f"""
             # DataBundle.get_all_outgoing_statements()
-            SELECT DISTINCT
-                ?p ?o (isLiteral(?o) as ?is_literal) 
-                (COALESCE(?o_label_, '') as ?o_label)
-                (COALESCE(?o_class_uri_, '') as ?o_class_uri)
+            SELECT
+                ?p ?o (isLiteral(?o) as ?is_literal)
+                (COALESCE(SAMPLE(?o_label_), '') as ?o_label)
+                (COALESCE(SAMPLE(?o_class_uri_), '') as ?o_class_uri)
             WHERE {{ 
                 {self.data.sparql_begin}
                     {entity_uri} ?p ?o  .
@@ -576,6 +607,7 @@ class DataBundle:
                     {f"FILTER(?p NOT IN ({skip_prop_str}))" if len(skip_props) else ""}
                 {self.data.sparql_end}
             }}
+            GROUP BY ?p ?o
         """
 
         # Execute query
@@ -621,7 +653,7 @@ class DataBundle:
             List[Statement]: A list of statements representing the incoming triples.
         """
         # Prepare the query
-        entity_uri = prepare(entity.uri, self.prefixes.shorts())
+        entity_uri = self._prepare_resource_uri(entity.uri)
         skip_prop_str = (
             ", ".join(
                 list(set([prepare(p.uri, self.prefixes.shorts()) for p in skip_props]))
@@ -631,10 +663,10 @@ class DataBundle:
         )
         query = f"""
             # DataBundle.get_all_outgoing_statements()
-            SELECT DISTINCT
+            SELECT
                 ?s ?p
-                (COALESCE(?s_label_, '') as ?s_label)
-                (COALESCE(?s_class_uri_, '') as ?s_class_uri)
+                (COALESCE(SAMPLE(?s_label_), '') as ?s_label)
+                (COALESCE(SAMPLE(?s_class_uri_), '') as ?s_class_uri)
             WHERE {{ 
                 {self.data.sparql_begin}
                     ?s ?p {entity_uri} .
@@ -643,6 +675,7 @@ class DataBundle:
                     {f"FILTER(?p NOT IN ({skip_prop_str}))" if len(skip_props) else ""}
                 {self.data.sparql_end}
             }}
+            GROUP BY ?s ?p
             LIMIT {limit}
             OFFSET {offset}
         """
@@ -676,7 +709,7 @@ class DataBundle:
             int: The number of incoming statements for the entity.
         """
         # Prepare the query
-        entity_uri = prepare(entity.uri, self.prefixes.shorts())
+        entity_uri = self._prepare_resource_uri(entity.uri)
         query = f"""
             # DataBundle.get_all_outgoing_statements()
             SELECT (COUNT(*) as ?count)
@@ -1214,15 +1247,15 @@ class DataBundle:
             Resource: An object containing the entity's URI, label, comment, and class URI.
         """
         # Make sure the URI is correctly formated
-        entity_uri = prepare(uri, self.prefixes.shorts())
+        entity_uri = self._prepare_resource_uri(uri)
 
         # Build the query text
         query = f"""
             # DataBundle.get_entity_basics()
             SELECT 
-                (COALESCE(?label_, '') as ?label)
-                (COALESCE(?comment_, '') as ?comment)
-                (COALESCE(?class_uri_, '') as ?class_uri)
+                (COALESCE(SAMPLE(?label_), '') as ?label)
+                (COALESCE(SAMPLE(?comment_), '') as ?comment)
+                (COALESCE(SAMPLE(?class_uri_), '') as ?class_uri)
             WHERE {{
                 {self.data.sparql_begin}
                     OPTIONAL {{ {entity_uri} {self.model.label_property} ?label_ . }}
@@ -1233,7 +1266,10 @@ class DataBundle:
         """
 
         # Execute the query
-        infos = self.data.run(query)[0]
+        response = self.data.run(query)
+        infos = (
+            response[0] if response else {"label": "", "comment": "", "class_uri": ""}
+        )
 
         # Build the resource
         resource = Resource(uri, infos["label"], infos["comment"], infos["class_uri"])

--- a/src/schema/data_bundle.py
+++ b/src/schema/data_bundle.py
@@ -111,7 +111,13 @@ class DataBundle:
         """
         # Fetch the Model
         try:
+            print(
+                f"[data_bundle] load_model start | bundle={self.name} | endpoint={self.endpoint.name if self.endpoint else None} | endpoint_url={self.endpoint.url if self.endpoint else None} | model_graph={self.model.uri}"
+            )
             self.model.update()
+            print(
+                f"[data_bundle] load_model done | bundle={self.name} | classes={len(self.model.classes)} | properties={len(self.model.properties)}"
+            )
         except HTTPError as err:
             status_code = err.response.status_code
             reason = err.response.reason

--- a/src/schema/data_bundle.py
+++ b/src/schema/data_bundle.py
@@ -1,4 +1,3 @@
-import re
 from typing import List, Tuple, Dict
 import pandas as pd
 from requests.exceptions import HTTPError
@@ -122,38 +121,6 @@ class DataBundle:
                 message += f"\n\n{err.response.text}"
             raise Exception(message)
 
-    def _prepare_resource_uri(self, value: str | None) -> str | None:
-        """
-        Prepare a resource IRI for SPARQL patterns.
-
-        Unlike graphly.tools.prepare, this helper preserves absolute non-HTTP IRIs
-        (e.g. urn:, doi:) as IRIs instead of falling back to quoted literals.
-        """
-        if value is None:
-            return None
-
-        uri = str(value).strip()
-        if not uri:
-            return None
-
-        if uri.startswith("?"):
-            return uri
-
-        if uri.startswith("<") and uri.endswith(">"):
-            return uri
-
-        prefixes = self.prefixes.shorts()
-        prefix_sep = uri.find(":")
-        if prefix_sep > 0:
-            prefix = uri[:prefix_sep]
-            if prefix in prefixes:
-                return uri
-
-            if re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", uri):
-                return f"<{uri}>"
-
-        return prepare(uri, prefixes)
-
     def has_usable_model(self) -> bool:
         """
         Indicate whether the current bundle has any non-datatype classes or properties loaded.
@@ -215,9 +182,9 @@ class DataBundle:
             # DataBundle.find_entities()
             SELECT
                 (?uri_ as ?uri)
-                (COALESCE(SAMPLE(?label_), '') as ?label)
-                (COALESCE(SAMPLE(?comment_), '') as ?comment)
-                (COALESCE(SAMPLE(?class_uri_), '{class_uri if class_uri else ""}') as ?class_uri)
+                (COALESCE(?label_, '') as ?label)
+                (COALESCE(?comment_, '') as ?comment)
+                (COALESCE(?class_uri_, '{class_uri if class_uri else ""}') as ?class_uri)
             WHERE {{
                 {self.data.sparql_begin}
                     ?uri_ {self.model.type_property} {prepared_class_uri if prepared_class_uri else "?class_uri_"} .
@@ -226,8 +193,6 @@ class DataBundle:
                 {self.data.sparql_end}
                 {filter_clause}
             }}
-            GROUP BY ?uri_
-            ORDER BY LCASE(STR(?label)) STR(?uri)
             {f"LIMIT {limit}" if limit else ""}
             {f"OFFSET {offset}" if offset else ""}
         """
@@ -262,7 +227,7 @@ class DataBundle:
             List[Property]: A list of properties outgoing from the given entity.
         """
         # Prepare the query
-        entity_uri = self._prepare_resource_uri(entity.uri)
+        entity_uri = prepare(entity.uri, self.prefixes.shorts())
         query = f"""
             SELECT DISTINCT 
                 ?uri 
@@ -309,7 +274,7 @@ class DataBundle:
             List[Property]: A list of properties incoming to the given entity.
         """
         # Prepare the query
-        entity_uri = self._prepare_resource_uri(entity.uri)
+        entity_uri = prepare(entity.uri, self.prefixes.shorts())
         query = f"""
             SELECT DISTINCT 
                 ?uri 
@@ -382,7 +347,7 @@ class DataBundle:
             List[Statement]: A list of statements representing the entity-property-object triples.
         """
         # Prepare the query
-        entity_uri = self._prepare_resource_uri(entity.uri)
+        entity_uri = prepare(entity.uri, self.prefixes.shorts())
         property_uri = prepare(property.uri, self.prefixes.shorts())
         object_class_uri = prepare(
             property.range.uri if property.range else None, self.prefixes.shorts()
@@ -394,9 +359,9 @@ class DataBundle:
             # DataBundle.get_objects_of()
             SELECT
                 ?object_uri
-                (COALESCE(SAMPLE(?object_label_), '') as ?object_label)
-                (COALESCE(SAMPLE(?object_comment_), '') as ?object_comment)
-                (COALESCE(SAMPLE(?object_class_uri_), IF(isLiteral(?object_uri), DATATYPE(?object_uri), '')) as ?object_class_uri)
+                (COALESCE(?object_label_, '') as ?object_label)
+                (COALESCE(?object_comment_, '') as ?object_comment)
+                (COALESCE(?object_class_uri_, IF(isLiteral(?object_uri), DATATYPE(?object_uri), '')) as ?object_class_uri)
                 (IF(isIRI(?object_uri), 'iri', IF(isBlank(?object_uri), 'blank', IF(isLiteral(?object_uri), 'literal', ''))) as ?resource_type)
             WHERE {{
                 {self.data.sparql_begin}
@@ -407,13 +372,15 @@ class DataBundle:
                     OPTIONAL {{ ?object_uri {self.model.type_property} ?object_class_uri_ . }}
                 {self.data.sparql_end}
             }}
-            GROUP BY ?object_uri
             {f"LIMIT {limit}" if limit else ""}
             {f"OFFSET {offset}" if offset else ""}
         """
 
         # Execute query
         response = self.data.run(query)
+
+        # Make it unique based on object URI (can have duplicates because of multiple lables, comments, ...)
+        response = list({d["object_uri"]: d for d in reversed(response)}.values())
 
         # Parse response into Statement instance list
         statements = [
@@ -448,7 +415,7 @@ class DataBundle:
             int: The number of objects associated with the entity via the property.
         """
         # Prepare the query
-        entity_uri = self._prepare_resource_uri(entity.uri)
+        entity_uri = prepare(entity.uri, self.prefixes.shorts())
         property_uri = prepare(property.uri, self.prefixes.shorts())
         query = f"""
             # DataBundle.get_objects_of_count()
@@ -486,7 +453,7 @@ class DataBundle:
             List[Statement]: A list of statements representing the subject-property-entity triples.
         """
         # Prepare the query
-        entity_uri = self._prepare_resource_uri(entity.uri)
+        entity_uri = prepare(entity.uri, self.prefixes.shorts())
         property_uri = prepare(property.uri, self.prefixes.shorts())
         subject_class_uri = prepare(
             property.domain.uri if property.domain else None, self.prefixes.shorts()
@@ -495,9 +462,9 @@ class DataBundle:
             # DataBundle.get_subjects_of()
             SELECT
                 ?subject_uri
-                (COALESCE(SAMPLE(?subject_label_), '') as ?subject_label)
-                (COALESCE(SAMPLE(?subject_comment_), '') as ?subject_comment)
-                (COALESCE(SAMPLE(?subject_class_uri_), IF(isLiteral(?subject_uri), DATATYPE(?subject_uri), '')) as ?subject_class_uri)
+                (COALESCE(?subject_label_, '') as ?subject_label)
+                (COALESCE(?subject_comment_, '') as ?subject_comment)
+                (COALESCE(?subject_class_uri_, IF(isLiteral(?subject_uri), DATATYPE(?subject_uri), '')) as ?subject_class_uri)
                 (IF(isIRI(?subject_uri), 'iri', IF(isBlank(?subject_uri), 'blank', IF(isLiteral(?subject_uri), 'literal', ''))) as ?resource_type)
             WHERE {{
                 {self.data.sparql_begin}
@@ -508,13 +475,15 @@ class DataBundle:
                     OPTIONAL {{ ?subject_uri {self.model.type_property} ?subject_class_uri_ . }}
                 {self.data.sparql_end}
             }}
-            GROUP BY ?subject_uri
             {f"LIMIT {limit}" if limit else ""}
             {f"OFFSET {offset}" if offset else ""}
         """
 
         # Execute query
         response = self.data.run(query)
+
+        # Make it unique based on subject URI (can have duplicates because of multiple lables, comments, ...)
+        response = list({d["subject_uri"]: d for d in reversed(response)}.values())
 
         # Parse response into Statement instance list
         statements = [
@@ -549,7 +518,7 @@ class DataBundle:
             int: The number of subjects associated with the entity via the property.
         """
         # Prepare the query
-        entity_uri = self._prepare_resource_uri(entity.uri)
+        entity_uri = prepare(entity.uri, self.prefixes.shorts())
         property_uri = prepare(property.uri, self.prefixes.shorts())
         query = f"""
             # DataBundle.get_objects_of_count()
@@ -585,7 +554,7 @@ class DataBundle:
             List[Statement]: A list of statements representing the outgoing triples.
         """
         # Prepare the query
-        entity_uri = self._prepare_resource_uri(entity.uri)
+        entity_uri = prepare(entity.uri, self.prefixes.shorts())
         skip_prop_str = (
             ", ".join(
                 list(set([prepare(p.uri, self.prefixes.shorts()) for p in skip_props]))
@@ -595,10 +564,10 @@ class DataBundle:
         )
         query = f"""
             # DataBundle.get_all_outgoing_statements()
-            SELECT
-                ?p ?o (isLiteral(?o) as ?is_literal)
-                (COALESCE(SAMPLE(?o_label_), '') as ?o_label)
-                (COALESCE(SAMPLE(?o_class_uri_), '') as ?o_class_uri)
+            SELECT DISTINCT
+                ?p ?o (isLiteral(?o) as ?is_literal) 
+                (COALESCE(?o_label_, '') as ?o_label)
+                (COALESCE(?o_class_uri_, '') as ?o_class_uri)
             WHERE {{ 
                 {self.data.sparql_begin}
                     {entity_uri} ?p ?o  .
@@ -607,7 +576,6 @@ class DataBundle:
                     {f"FILTER(?p NOT IN ({skip_prop_str}))" if len(skip_props) else ""}
                 {self.data.sparql_end}
             }}
-            GROUP BY ?p ?o
         """
 
         # Execute query
@@ -653,7 +621,7 @@ class DataBundle:
             List[Statement]: A list of statements representing the incoming triples.
         """
         # Prepare the query
-        entity_uri = self._prepare_resource_uri(entity.uri)
+        entity_uri = prepare(entity.uri, self.prefixes.shorts())
         skip_prop_str = (
             ", ".join(
                 list(set([prepare(p.uri, self.prefixes.shorts()) for p in skip_props]))
@@ -663,10 +631,10 @@ class DataBundle:
         )
         query = f"""
             # DataBundle.get_all_outgoing_statements()
-            SELECT
+            SELECT DISTINCT
                 ?s ?p
-                (COALESCE(SAMPLE(?s_label_), '') as ?s_label)
-                (COALESCE(SAMPLE(?s_class_uri_), '') as ?s_class_uri)
+                (COALESCE(?s_label_, '') as ?s_label)
+                (COALESCE(?s_class_uri_, '') as ?s_class_uri)
             WHERE {{ 
                 {self.data.sparql_begin}
                     ?s ?p {entity_uri} .
@@ -675,7 +643,6 @@ class DataBundle:
                     {f"FILTER(?p NOT IN ({skip_prop_str}))" if len(skip_props) else ""}
                 {self.data.sparql_end}
             }}
-            GROUP BY ?s ?p
             LIMIT {limit}
             OFFSET {offset}
         """
@@ -709,7 +676,7 @@ class DataBundle:
             int: The number of incoming statements for the entity.
         """
         # Prepare the query
-        entity_uri = self._prepare_resource_uri(entity.uri)
+        entity_uri = prepare(entity.uri, self.prefixes.shorts())
         query = f"""
             # DataBundle.get_all_outgoing_statements()
             SELECT (COUNT(*) as ?count)
@@ -1247,15 +1214,15 @@ class DataBundle:
             Resource: An object containing the entity's URI, label, comment, and class URI.
         """
         # Make sure the URI is correctly formated
-        entity_uri = self._prepare_resource_uri(uri)
+        entity_uri = prepare(uri, self.prefixes.shorts())
 
         # Build the query text
         query = f"""
             # DataBundle.get_entity_basics()
             SELECT 
-                (COALESCE(SAMPLE(?label_), '') as ?label)
-                (COALESCE(SAMPLE(?comment_), '') as ?comment)
-                (COALESCE(SAMPLE(?class_uri_), '') as ?class_uri)
+                (COALESCE(?label_, '') as ?label)
+                (COALESCE(?comment_, '') as ?comment)
+                (COALESCE(?class_uri_, '') as ?class_uri)
             WHERE {{
                 {self.data.sparql_begin}
                     OPTIONAL {{ {entity_uri} {self.model.label_property} ?label_ . }}
@@ -1266,10 +1233,7 @@ class DataBundle:
         """
 
         # Execute the query
-        response = self.data.run(query)
-        infos = (
-            response[0] if response else {"label": "", "comment": "", "class_uri": ""}
-        )
+        infos = self.data.run(query)[0]
 
         # Build the resource
         resource = Resource(uri, infos["label"], infos["comment"], infos["class_uri"])

--- a/src/schema/sparql_technologies.py
+++ b/src/schema/sparql_technologies.py
@@ -22,6 +22,11 @@ def _extract_declared_prefix_shorts(query_text: str) -> set[str]:
     return {match.group(1) for match in PREFIX_DECLARATION_RE.finditer(query_text)}
 
 
+def _query_preview(text: str, max_length: int = 220) -> str:
+    compact = " ".join((text or "").split())
+    return compact if len(compact) <= max_length else compact[:max_length] + "..."
+
+
 def _patch_graphly_parser() -> None:
     graphly_sparql.parse_sparql_json_response = parse_sparql_json_response
 
@@ -97,7 +102,19 @@ def _patch_graphly_timeout() -> None:
                 return graphly_sparql.parse_sparql_json_response(
                     response.json(), prefixes
                 )
-            except Exception:
+            except Exception as err:
+                content_type = response.headers.get("Content-Type", "")
+                preview = response.text.strip()
+                if len(preview) > 400:
+                    preview = preview[:400] + "..."
+                print(
+                    "[sparql] JSON parse failed | "
+                    f"url={self.url + url_appendix} | "
+                    f"content_type={content_type or '(missing)'} | "
+                    f"query={_query_preview(text)} | "
+                    f"error={err} | "
+                    f"response={preview}"
+                )
                 return response.text
 
     graphly_sparql.Sparql.run = _run_with_timeout

--- a/src/schema/sparql_technologies.py
+++ b/src/schema/sparql_technologies.py
@@ -32,12 +32,12 @@ def _patch_graphly_parser() -> None:
 
 
 def _get_sparql_timeout_seconds() -> float:
-    raw_value = os.getenv("LOGRE_SPARQL_TIMEOUT", "12")
+    raw_value = os.getenv("LOGRE_SPARQL_TIMEOUT", "120")
     try:
         parsed = float(raw_value)
     except (TypeError, ValueError):
-        return 12.0
-    return parsed if parsed > 0 else 12.0
+        return 120.0
+    return parsed if parsed > 0 else 120.0
 
 
 def _get_nquads_chunk_lines() -> int:


### PR DESCRIPTION
- raise default SPARQL timeout from 12s to 120s
- fix duplicate Streamlit keys in entity triples
- improve SPARQL debug logging
- add import/model loading debug traces